### PR TITLE
Use specific import paths for wally subpackages

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-	"wally/wally"
+	"github.com/zsa/wally/wally"
 )
 
 func main() {

--- a/ui.go
+++ b/ui.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/fdidron/webview"
-	"wally/wally"
+	"github.com/zsa/wally/wally"
 )
 
 func handleRPC(w webview.WebView, data string, s *wally.State) {

--- a/ui_dev.go
+++ b/ui_dev.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"github.com/fdidron/webview"
-	"wally/wally"
+	"github.com/zsa/wally/wally"
 )
 
 // Init returns a configured and ready to use webview.

--- a/ui_dist.go
+++ b/ui_dist.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"github.com/fdidron/webview"
-	"wally/wally"
+	"github.com/zsa/wally/wally"
 )
 
 // Init returns a configured and ready to use webview.


### PR DESCRIPTION
This should fix any issues if someone uses `go get github.com/zsa/wally` and tries to compile, it also will allow proper go module support for building