### PR TITLE
Add 50-oryx.rules

### DIFF
--- a/dist/linux64/50-oryx.rules
+++ b/dist/linux64/50-oryx.rules
@@ -1,0 +1,4 @@
+# Rule for the Ergodox EZ Original / Shine / Glow
+SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", GROUP="plugdev"
+# Rule for the Planck EZ Standard / Glow
+SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", GROUP="plugdev"


### PR DESCRIPTION
While `50-wally.rules` exists as file, `50-oryx.rules` is missing.

This helps linux distros to package it and support the hardware.

@fdidron feel free to use it in the ppa.