### PR TITLE
Update Readme to link CLI release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Flash your [ZSA Keyboard](https://ergodox-ez.com) the EZ way.
 ## Getting started
 
 Wally comes in two flavors, a GUI and a CLI app.
-Download the application for your favorite platform from the [release page](https://github.com/zsa/wally/releases).
+Download the application for your favorite platform from the relevant release page: [GUI](https://github.com/zsa/wally/releases) / [CLI](https://github.com/zsa/wally-cli/releases).
 
 Note for Linux users, follow the instructions from our [wiki page](https://github.com/zsa/wally/wiki/Linux-install) before running the application.
 


### PR DESCRIPTION
It took me 30 mins or so to find the CLI repo because it's not linked anywhere in this repo or on the ZSA website, despite its existence being mentioned in both places.

I'm completely indifferent on how this is phrased, but there should really be a link somewhere.