### PR TITLE
add moonlander to oryx udev rules

### DIFF
--- a/dist/linux64/50-oryx.rules
+++ b/dist/linux64/50-oryx.rules
@@ -1,3 +1,5 @@
+# Rule for the Moonlander
+SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", GROUP="plugdev"
 # Rule for the Ergodox EZ Original / Shine / Glow
 SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", GROUP="plugdev"
 # Rule for the Planck EZ Standard / Glow

--- a/dist/linux64/50-wally.rules
+++ b/dist/linux64/50-wally.rules
@@ -4,7 +4,7 @@ ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789A]?", ENV{MTP_NO_PROBE}="1"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", MODE:="0666"
 KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", MODE:="0666"
 
-# STM32 rules for the Planck EZ Standard / Glow
+# STM32 rules for the Moonlander and Planck EZ Standard / Glow
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", \
     MODE:="0666", \
     SYMLINK+="stm32_dfu"


### PR DESCRIPTION
Updated from the latest [Linux instructions](https://github.com/zsa/wally/wiki/Live-training-on-Linux)