### PR TITLE
Automated Linux install for all distributions and wally-cli compilation for ARM devices like RaspberryPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ Wally is compatible with Windows, Linux, and macOS. Developing using each platfo
 
 #### Linux
 
-Follow the instructions from our [wiki page](https://github.com/zsa/wally/wiki/Linux-install)
+Follow the instructions from our [wiki page](https://github.com/zsa/wally/wiki/Linux-install) or run the `install.linux.sh`.
+`install.linux.sh` should install all needed packages according to your x86 distribution.
+If you try to get wally working on a RaspberryPi, which has an ARM architecture, the script will compile the `wally-cli` for you and set it as alias in your bash.
+Installing should be as easy as running `./install.linux.sh`
 
 #### macOS
 

--- a/install.linux.sh
+++ b/install.linux.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+if [[ "$USER" == 'root' ]]; then
+    echo -e "\n\tPlease run script as non-root user!\n"
+    exit 1
+else
+    cd $HOME
+fi
+
+# GLOBALS
+goUrl='https://dl.google.com/go/go1.13.7.linux-armv6l.tar.gz'
+wallyBin='https://configure.ergodox-ez.com/wally/linux'
+wallyCli='github.com/zsa/wally-cli'
+
+# INSTALL
+declare -A packageAA=(
+    ['apt-get']='
+        gtk+3.0
+        libwebkit2gtk-4.0
+        libusb-dev
+        libusb-1.0
+    '
+    ['yum']='
+        gtk3
+        webkit2gtk3
+        libusb
+    '
+    ['pacman']='
+        gtk3
+        webkit2gtk
+        libusb
+    '
+)
+for key in ${!packageAA[@]}; do
+    which $key && sudo $key install -y ${packageAA[$key]}
+done
+
+# WALLY UDEV RULE FOR DEVICE RELATED EVENT
+cat <<EOF | sudo tee /etc/udev/rules.d/50-wally.rules
+# Teensy rules for the Ergodox EZ
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789A]?", ENV{MTP_NO_PROBE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", MODE:="0666"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", MODE:="0666"
+# STM32 rules for the Moonlander and Planck EZ
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666", SYMLINK+="stm32_dfu"
+EOF
+
+# ADD USER TO PLUGDEV GROUP
+sudo groupadd plugdev
+sudo usermod -aG plugdev $USER
+
+# HARDWARE PLATFORM DEPENDENT WALLY
+if [[ "$(uname -i)" =~ 'x86' ]]; then
+    curl -OSL $wallyBin
+    sudo chmod +x wally
+    echo -e "You can launch the GUI via\n\t./wally "
+else
+    curl -SL $goUrl -O go.tar.gz
+    sudo tar -C /usr/local -xzf go.tar.gz
+    cat <<\EOF | sed -r 's/^ *//' >>$HOME/.bashrc
+        alias wally-cli='$HOME/go/bin/linux_arm64/wally-cli'
+        export GOPATH=$HOME/go
+        export PATH=/usr/local/go/bin:$PATH:$GOPATH/bin
+        export CC=aarch64-linux-gnu-gcc
+        export GOARCH=arm64
+        export GOOS=linux
+        export CGO_ENABLED=1
+EOF
+    . $HOME/.bashrc
+    go get -u $wallyCli
+    echo -e "Now you can run wally like this:\n\twally-cli <firmware-file>"
+fi
+
+echo 'Done.'


### PR DESCRIPTION
Bash script uses an associative array to determine needed packages for installation and package-manager.
This array is legible and easy to maintain for future adaptations.
Also, creating and chmodding udev rules was automated.

Most importantly, it is also possible to run wall-cli from ARM devices such as RaspberryPi.
The script checks the platform architecture (uname -i) and then downloads needed go packages and sets GO environment variables. Last, but not least, an alias is created in the bashrc for easy invocation.

All in all, provided could should greatly simplify the installation process on any Linux platform. 
