### PR TITLE
Reset bytes sent each flash operation

### DIFF
--- a/wally/dfu.go
+++ b/wally/dfu.go
@@ -181,6 +181,7 @@ func DFUFlash(s *State) {
 	defer cfg.Close()
 
 	fileSize := len(firmwareData)
+	s.FlashProgress.Sent = 0
 	s.FlashProgress.Total = fileSize
 
 	err = dfuClearStatus(dev)

--- a/wally/teensy.go
+++ b/wally/teensy.go
@@ -19,6 +19,7 @@ func TeensyFlash(s *State) {
 	}
 	defer file.Close()
 
+	s.FlashProgress.Sent = 0
 	s.FlashProgress.Total = ergodoxCodeSize
 
 	firmware := gohex.NewMemory()


### PR DESCRIPTION
When you drop a new firmware right after a previous flash operation the progress bar would not reset.