### PR TITLE
Add STM32 rules for Moonlander et al.

### DIFF
--- a/dist/linux64/50-oryx.rules
+++ b/dist/linux64/50-oryx.rules
@@ -4,3 +4,5 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", TAG+="uaccess
 SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", TAG+="uaccess", TAG+="udev-acl"
 # Rule for the Planck EZ Standard / Glow
 SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", TAG+="uaccess", TAG+="udev-acl"
+# STM32 rules for the Moonlander and Planck EZ Standard / Glow
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="df11", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
The udev rules didn't work for me, as the USB-ID is different when the device is in flashing mode.
It does work for me when adding the ID of the device STMicroelectronics STM Device in DFU Mode.