### PR TITLE
Use separate mapping for distro install commands

### DIFF
--- a/install.linux.sh
+++ b/install.linux.sh
@@ -31,8 +31,15 @@ declare -A packageAA=(
         libusb
     '
 )
+
+declare -A commandAA=(
+    ['apt-get']='install -y'
+    ['yum']='install -y'
+    ['pacman']='--noconfirm -S'
+)
+
 for key in ${!packageAA[@]}; do
-    which $key && sudo $key install -y ${packageAA[$key]}
+    which $key && sudo $key ${commandAA[$key]} ${packageAA[$key]}
 done
 
 # WALLY UDEV RULE FOR DEVICE RELATED EVENT


### PR DESCRIPTION
On Arch Linux, pacman doesn't follow the same conventions as "apt-get"
and "yum", so the install script failed at the dependencies stage. This
introduces a new mapping of "package manager -> install command" to
improve cross distro support (and to fix the script for Arch builds).