### PR TITLE
Modernize udev rules

### DIFF
--- a/dist/linux64/50-oryx.rules
+++ b/dist/linux64/50-oryx.rules
@@ -1,6 +1,6 @@
 # Rule for the Moonlander
-SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", TAG+="uaccess"
 # Rule for the Ergodox EZ Original / Shine / Glow
-SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", TAG+="uaccess"
 # Rule for the Planck EZ Standard / Glow
-SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", TAG+="uaccess"

--- a/dist/linux64/50-wally.rules
+++ b/dist/linux64/50-wally.rules
@@ -1,10 +1,8 @@
 # Teensy rules for the Ergodox EZ Original / Shine / Glow
 ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", ENV{ID_MM_DEVICE_IGNORE}="1"
 ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789A]?", ENV{MTP_NO_PROBE}="1"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", MODE:="0666"
-KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", TAG+="uaccess"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", TAG+="uaccess"
 
 # STM32 rules for the Moonlander and Planck EZ Standard / Glow
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", \
-    MODE:="0666", \
-    SYMLINK+="stm32_dfu"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", TAG+="uaccess", SYMLINK+="stm32_dfu"

--- a/install.linux.sh
+++ b/install.linux.sh
@@ -35,20 +35,9 @@ for key in ${!packageAA[@]}; do
     which $key && sudo $key install -y ${packageAA[$key]}
 done
 
-# WALLY UDEV RULE FOR DEVICE RELATED EVENT
-cat <<EOF | sudo tee /etc/udev/rules.d/50-wally.rules
-# Teensy rules for the Ergodox EZ
-ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", ENV{ID_MM_DEVICE_IGNORE}="1"
-ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789A]?", ENV{MTP_NO_PROBE}="1"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789ABCD]?", MODE:="0666"
-KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", MODE:="0666"
-# STM32 rules for the Moonlander and Planck EZ
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666", SYMLINK+="stm32_dfu"
-EOF
-
-# ADD USER TO PLUGDEV GROUP
-sudo groupadd plugdev
-sudo usermod -aG plugdev $USER
+# UDEV RULES
+install -m644 -t /etc/udev/rules.d/ \
+    dist/linux64/50-oryx.rules dist/linux64/50-wally.rules
 
 # HARDWARE PLATFORM DEPENDENT WALLY
 if [[ "$(uname -i)" =~ 'x86' ]]; then


### PR DESCRIPTION
Replace world-writable permissions in 50-wally.rules with `uaccess` tag which limits device access to the current user, see https://github.com/systemd/systemd/issues/4288

Also remove the legacy `udev-acl` tag from 50-oryx.rules; modern Linux systems do not use this tag and ship no udev rules for it.