### PR TITLE
Create pipeline for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM centos:centos8
+
+RUN dnf install -y dnf-plugins-core && \
+  dnf config-manager --set-enabled powertools && \
+  dnf install -y \
+    gcc gtk3 gtk3-devel \
+    libusb libusb-devel \
+    nodejs npm pkg-config \
+    webkit2gtk3 webkit2gtk3-devel wget && \
+  mkdir project && \
+  wget https://golang.org/dl/go1.16.6.linux-amd64.tar.gz -O go.tar.gz
+
+RUN tar -zxf go.tar.gz && \
+  cp -r ./go /usr/local/bin
+
+ENV PATH=$PATH:/usr/local/bin/go/bin
+
+WORKDIR project
+COPY /*.go ./
+COPY /go.mod ./go.mod
+COPY /go.sum ./go.sum
+COPY /frontend ./frontend
+COPY /project.json ./project.json
+COPY /wally ./wally
+
+WORKDIR frontend
+
+RUN npm install && \
+  npm run build
+
+WORKDIR ..
+
+RUN go build -o wally-bin
+ENTRYPOINT ["sleep", "infinity"]

--- a/build.linux.sh
+++ b/build.linux.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+CONTAINER_NAME="$(uuidgen)"
+
+docker build -t wally .
+docker run --rm -d --name "$CONTAINER_NAME" wally
+
+docker cp $CONTAINER_NAME:/project/wally-bin ./dist/linux64/wally
+
+docker kill --signal SIGKILL "$CONTAINER_NAME"
+

--- a/build.linux.sh
+++ b/build.linux.sh
@@ -10,4 +10,3 @@ docker run --rm -d --name "$CONTAINER_NAME" wally
 docker cp $CONTAINER_NAME:/project/wally-bin ./dist/linux64/wally
 
 docker kill --signal SIGKILL "$CONTAINER_NAME"
-


### PR DESCRIPTION
I couldn't find anywhere to make reproducible builds on Linux so I decided to make a docker build container to make it easy for anyone to build the project!

Likewise, currently the Linux builds use a fairly new version of glibc. This means even though the [docs](https://github.com/zsa/wally/wiki/Linux-install#13-red-hat--fedora-and-its-derivatives-centos-scientific-linux-) talk about using wally with RHEL type OSes, anyone who runs the wally binary in the releases section with a RHEL (or probably even Debian) will get an error that looks like this:

```
$ ./wally
./wally: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./wally)
```

Centos generally uses the oldest glibc across modern Linux distros and does not do any major upgrades for 10 or so years. The image I picked therefore should be good for hitting the lowest common denominator for nearly a decade.

All you need to run is `podman` or `docker` installed. Then you can just do `./build.linux.sh` and a binary will show up in `./dist/linux64/wally`

I would recommend making all future releases with this docker build or something like it so folks with older glibc versions can just download and run without any issues.

PR typed v e r y slowly on my new Moonlander keyboard :)