### PR TITLE
Bumping version of wails in go.mod to 1.16.7 (fixes compilation error)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/wailsapp/wails v1.16.6
+	github.com/wailsapp/wails v1.16.7
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect


### PR DESCRIPTION
When running `./build.linux.sh` the build process fails:
```bash
...
Step 15/16 : RUN wails build
 ---> Running in 1a80fb79b4ac
Wails v1.16.7 - Building Application

✓ Ensuring frontend dependencies are up to date (This may take a while)
✓ Building frontend...
✓ Ensuring Dependencies are up to date...
✓ Updating go.mod (Wails version 1.16.6 => v1.16.7)
go: github.com/wailsapp/wails@v1.16.7: missing go.sum entry; to add it:
        go mod download github.com/wailsapp/wails


✗ Packing + Compiling project...
Error: exit status 1
The command '/bin/sh -c wails build' returned a non-zero code: 1
```

This minor change fixes the compilation problem.