### PR TITLE
Specify Wails version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH=$PATH:/usr/local/bin/go/bin
 ENV GOPATH=/usr/local/bin/go
 
 RUN npm i -g yarn
-RUN go get -u github.com/wailsapp/wails/cmd/wails
+RUN go get -u github.com/wailsapp/wails/cmd/wails@v1.16.7
 
 WORKDIR project
 COPY /*.go ./


### PR DESCRIPTION
The `build.linux.sh` script currently fails. The Dockerfile defaults to the latest version of Wails, which breaks the build. 

This PR locks Wails version at `1.16.7`. 