### PR TITLE
Fix for several build issues with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
 FROM centos:centos8
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum update -y
+
 RUN dnf install -y dnf-plugins-core && \
-  dnf config-manager --set-enabled powertools && \
-  dnf install -y \
-    gcc gtk3 gtk3-devel \
-    libusb-devel \
-    nodejs npm pkg-config \
-    webkit2gtk3-devel wget && \
-  mkdir project && \
-  wget https://golang.org/dl/go1.16.6.linux-amd64.tar.gz -O go.tar.gz
+    dnf config-manager --set-enabled powertools && \
+    dnf install -y \
+      gcc gtk3 gtk3-devel \
+      libusb-devel \
+      nodejs npm pkg-config \
+      webkit2gtk3-devel wget && \
+    mkdir project && \
+    wget https://go.dev/dl/go1.19.1.linux-amd64.tar.gz -O go.tar.gz
 
 RUN tar -zxf go.tar.gz && \
-  cp -r ./go /usr/local/bin
+    cp -r ./go /usr/local/bin
 
 ENV PATH=$PATH:/usr/local/bin/go/bin
 ENV GOPATH=/usr/local/bin/go
-
-RUN npm i -g yarn
-RUN go get -u github.com/wailsapp/wails/cmd/wails@v1.16.7
 
 WORKDIR project
 COPY /*.go ./
@@ -26,6 +27,9 @@ COPY /go.sum ./go.sum
 COPY /frontend ./frontend
 COPY /project.json ./project.json
 COPY /wally ./wally
+
+RUN npm i -g yarn
+RUN go install github.com/wailsapp/wails/cmd/wails@v1.16.7
 
 RUN wails build
 ENTRYPOINT ["sleep", "infinity"]


### PR DESCRIPTION
Tried to build locally (Linux) and received several failures during the docker build phase.

1) Received a "Failed to download metadata for { repo }" during the initial dnf* commands. Added the sed commands to address this issue.

2) After completing the "yum" phase, I received an error during installation of wails that go v1.17 or higher was required. I went ahead and installed the latest LTS 1.19.1. 

3) This change also required me to update the "go get -u" command to use "go install" instead.

4) Run wails after project files have been copied over. If you try to install wails before go.mod/project.json are copied, you receive a failure related to the files not existing.

With these changes in place, I was able to build Wally locally and run it from the /dist/linux64 directory.