### PR TITLE
Add udev rules for firmware v21+

### DIFF
--- a/dist/linux64/50-oryx-legacy.rules
+++ b/dist/linux64/50-oryx-legacy.rules
@@ -1,0 +1,9 @@
+# Legacy rules for live training over webusb (not needed for firmware v21+)
+# Rule for all ZSA keyboards
+SUBSYSTEM=="usb", ATTR{idVendor}=="3297", TAG+="uaccess"
+# Rule for the Moonlander
+SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", TAG+="uaccess"
+# Rule for the Ergodox EZ Original / Shine / Glow
+SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", TAG+="uaccess"
+# Rule for the Planck EZ Standard / Glow
+SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", TAG+="uaccess"

--- a/dist/linux64/50-oryx.rules
+++ b/dist/linux64/50-oryx.rules
@@ -1,6 +1,3 @@
-# Rule for the Moonlander
-SUBSYSTEM=="usb", ATTR{idVendor}=="3297", ATTR{idProduct}=="1969", TAG+="uaccess"
-# Rule for the Ergodox EZ Original / Shine / Glow
-SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="1307", TAG+="uaccess"
-# Rule for the Planck EZ Standard / Glow
-SUBSYSTEM=="usb", ATTR{idVendor}=="feed", ATTR{idProduct}=="6060", TAG+="uaccess"
+# Rules for Oryx web flashing and live training
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16c0", TAG+="uaccess"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3297", TAG+="uaccess"


### PR DESCRIPTION
Moved the rules for older firmwares into 50-oryx-legacy.rules to ease distributions in case they want to separately package the old vs. new rules.