### PR TITLE
Update wails in go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/syossan27/tebata v0.0.0-20180602121909-b283fe4bc5ba h1:2DHfQOxcpWdGf5
 github.com/syossan27/tebata v0.0.0-20180602121909-b283fe4bc5ba/go.mod h1:iLnlXG2Pakcii2CU0cbY07DRCSvpWNa7nFxtevhOChk=
 github.com/wailsapp/wails v1.16.6 h1:iN0tP0O/Gwr8SKWwgH4t+IqDlMCGeVquWoHTegk8JlQ=
 github.com/wailsapp/wails v1.16.6/go.mod h1:aADbAvTzZrKGd4Td7d1l4Dp5Hx7lLJEvVH7guIHoDf8=
+github.com/wailsapp/wails v1.16.7 h1:3IzaaHrQuN55mGzPcQK7kJ5pealDtJvI4z/XVHM7sns=
+github.com/wailsapp/wails v1.16.7/go.mod h1:aADbAvTzZrKGd4Td7d1l4Dp5Hx7lLJEvVH7guIHoDf8=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Summary: Fixes mismatch in wails version between `go.mod` and `go.sum`. Fixes the following issue with vendoring mods:

Before:

```
$ go mod vendor && echo success
go: github.com/wailsapp/wails@v1.16.7: missing go.sum entry for go.mod file; to add it:
        go mod download github.com/wailsapp/wails
```

After:

```
$ go mod vendor && echo success
success
```