### PR TITLE
Add voyager rule

### DIFF
--- a/dist/linux64/50-wally.rules
+++ b/dist/linux64/50-wally.rules
@@ -6,3 +6,5 @@ KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789B]?", TAG+=
 
 # STM32 rules for the Moonlander and Planck EZ Standard / Glow
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", TAG+="uaccess", SYMLINK+="stm32_dfu"
+# Voyager
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="3297", MODE:="0666", SYMLINK+="ignition_dfu"


### PR DESCRIPTION
Adds voyager rule.

While this rule is mentioned in the wiki (added [here](https://github.com/zsa/wally/wiki/Linux-install/_compare/541a04deccc46daf74678aac899bfe6acc66e09b...b5a858d358c8ef5c0522800bcc88555599f0ce07#diff-60e253d2c467435c2d0f0709a8620517fcc9b58d1de9f7aad4c6b548b26dfe1dR63-R64)), however some distros like nixOS depend on the actual file.

See discussion here: https://github.com/NixOS/nixpkgs/pull/258292